### PR TITLE
Add nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663905476,
+        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "A pure-C CSS parser forked from katana-parser.";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "aarch64-linux"
+        "i686-linux"
+        "riscv64-linux"
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.stdenv.mkDerivation {
+            name = "cssparser";
+            src = self;
+
+            outputs = [ "out" "dev" ];
+            enableParallelBuilding = true;
+            nativeBuildInputs = with pkgs; [ autoconf automake libtool gnumake autoreconfHook ];
+
+            meta = with pkgs.lib; {
+              homepage = "https://github.com/pepstack/cssparser";
+              license = with licenses; [ mit ];
+              maintainers = [ "Tristan Ross" "pepstack" ];
+            };
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ autoconf automake libtool gnumake autoreconfHook ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
This PR introduces a nix Flake which allows for usage with nix files. You can build the package using the nix package manager with `nix build`. More information can be found on the nix wiki.